### PR TITLE
Add Cypress end-to-end test suite (with RFID emulators) and CircIT port override

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -81,7 +81,7 @@ jobs:
           KTD_NAME: rfid
           BASE_URL: http://localhost:8081
           EMULATORS_DIR: ${{ github.workspace }}/emulators
-          VENDORS: "mksolutions bibliotheca"
+          VENDORS: "mksolutions bibliotheca circit"
         run: bash t/cypress/run.sh
 
       - name: Upload screenshots on failure

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,105 @@
+name: Cypress E2E
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  cypress:
+    name: Cypress E2E (per vendor)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout plugin code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      # Private repo of vendor RFID reader emulators. GHA_WORKFLOW_TOKEN must
+      # have read access to bywatersolutions/rfid-emulators.
+      - name: Checkout RFID emulators
+        uses: actions/checkout@v4
+        with:
+          repository: bywatersolutions/rfid-emulators
+          token: ${{ secrets.GHA_WORKFLOW_TOKEN }}
+          path: emulators
+
+      - name: Get Koha version branch name
+        id: koha-version
+        uses: "bywatersolutions/github-action-koha-get-version-by-label@v2"
+        with:
+          version-label: "main"
+
+      - name: Check out Koha
+        run: |
+          git clone --branch ${{ steps.koha-version.outputs.current-branch-name }} \
+            --single-branch --depth 1 \
+            https://github.com/Koha-Community/Koha.git "$GITHUB_WORKSPACE/kohaclone"
+
+      - name: Install koha-testing-docker
+        run: |
+          git clone https://gitlab.com/koha-community/koha-testing-docker.git "$GITHUB_WORKSPACE/ktd"
+          cp "$GITHUB_WORKSPACE/ktd/env/defaults.env" "$GITHUB_WORKSPACE/ktd/.env"
+          echo "$GITHUB_WORKSPACE/ktd/bin" >> "$GITHUB_PATH"
+
+      - name: Launch ktd with the plugin mounted
+        run: |
+          export LOCAL_USER_ID=$(id -u)
+          export KTD_HOME="$GITHUB_WORKSPACE/ktd"
+          export SYNC_REPO="$GITHUB_WORKSPACE/kohaclone"
+          export KOHA_IMAGE=main
+          ktd --name rfid --single-plugin "$GITHUB_WORKSPACE/plugin" up -d
+          ktd --name rfid --wait-ready 500
+
+      - name: Install and enable the plugin
+        run: |
+          export KTD_HOME="$GITHUB_WORKSPACE/ktd"
+          ktd --name rfid --shell --run "perl misc/devel/install_plugins.pl"
+          ktd --name rfid --shell --run "echo \"INSERT INTO plugin_data (plugin_class,plugin_key,plugin_value) VALUES ('Koha::Plugin::Com::ByWaterSolutions::RFID','__ENABLED__','1') ON DUPLICATE KEY UPDATE plugin_value='1';\" | koha-mysql kohadev"
+          ktd --name rfid --shell --run "sudo koha-plack --restart kohadev; flush_memcached"
+
+      - name: Install Mojolicious (to run the emulators)
+        run: sudo apt-get update && sudo apt-get install -y libmojolicious-perl
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Cypress and dependencies
+        uses: cypress-io/github-action@v6
+        with:
+          working-directory: plugin
+          runTests: false
+
+      - name: Run Cypress suite for each vendor
+        working-directory: plugin
+        env:
+          KTD_HOME: ${{ github.workspace }}/ktd
+          KTD_NAME: rfid
+          BASE_URL: http://localhost:8081
+          EMULATORS_DIR: ${{ github.workspace }}/emulators
+          VENDORS: "mksolutions bibliotheca"
+        run: bash t/cypress/run.sh
+
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots
+          path: plugin/t/cypress/screenshots
+          if-no-files-found: ignore
+
+      - name: Show Koha logs on failure
+        if: failure()
+        run: |
+          export KTD_HOME="$GITHUB_WORKSPACE/ktd"
+          ktd --name rfid --shell --run "tail -80 /var/log/koha/kohadev/plack-intranet-error.log" || true
+
+      - name: Cleanup ktd
+        if: always()
+        run: |
+          export KTD_HOME="$GITHUB_WORKSPACE/ktd"
+          ktd --name rfid down || true

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,14 +13,14 @@ jobs:
 
     steps:
       - name: Checkout plugin code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: plugin
 
       # Private repo of vendor RFID reader emulators. GHA_WORKFLOW_TOKEN must
       # have read access to bywatersolutions/rfid-emulators.
       - name: Checkout RFID emulators
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: bywatersolutions/rfid-emulators
           token: ${{ secrets.GHA_WORKFLOW_TOKEN }}
@@ -64,12 +64,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmojolicious-perl
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
       - name: Install Cypress and dependencies
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: plugin
           runTests: false
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload screenshots on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cypress-screenshots
           path: plugin/t/cypress/screenshots

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout plugin code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Get Koha Version Branch Name
       id: koha-version
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Release
       uses: softprops/action-gh-release@v2
@@ -115,7 +115,7 @@ jobs:
     name: Keep Alive
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Check age and push commit if needed
       run: |
         LAST_COMMIT=$( git --no-pager log -1 --format=%ct )

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/node_modules/
+
+# Cypress run artifacts
+t/cypress/screenshots/
+t/cypress/videos/
+t/cypress/downloads/
+
+# Generated at run time by t/cypress/run.sh from seed.pl
+t/cypress/fixtures/seed.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The CircIT reader port can be overridden via the `KOHA_RFID_CIRCIT_PORT` environment variable or the `RFIDCircitPort` system preference (defaults to port 80 under `/Temporary_Listen_Addresses`)
+
 ### Fixed
 
 - Checkout now halts on the "needs confirmation" alert for an available item that has an untrapped hold. The confirmation on the checkout page uses the `#circ_needsconfirmation` id, not the `#circ-needsconfirmation-modal` id used on the checkin page, so the plugin no longer recognized it and could skip past the held item without the librarian acting on it.

--- a/Koha/Plugin/Com/ByWaterSolutions/RFID.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/RFID.pm
@@ -103,7 +103,24 @@ sub intranet_js {
         return q{} if $rfid_disabled;
     }
 
-    return q{
+    # The CircIT reader port can be overridden for non-standard installs or for
+    # testing, via the KOHA_RFID_CIRCIT_PORT environment variable or the
+    # RFIDCircitPort system preference ( the env var wins if both are set ).
+    my $circit_port = $ENV{KOHA_RFID_CIRCIT_PORT};
+    $circit_port = C4::Context->preference('RFIDCircitPort')
+        unless defined $circit_port && $circit_port ne q{};
+
+    my $config_js = q{};
+    # Only accept a plain numeric port, so nothing unsafe ends up in the page
+    if ( defined $circit_port && $circit_port =~ /\A[0-9]{1,5}\z/ ) {
+        $config_js = qq{
+     <script type="text/javascript">
+       window.koha_plugin_rfid = window.koha_plugin_rfid || {};
+       window.koha_plugin_rfid.circit_port = "$circit_port";
+     </script>};
+    }
+
+    return $config_js . q{
      <script type="text/javascript" src="/api/v1/contrib/rfid/static/static_files/rfid.js"></script>
     };
 }

--- a/Koha/Plugin/Com/ByWaterSolutions/RFID/static_files/rfid.js
+++ b/Koha/Plugin/Com/ByWaterSolutions/RFID/static_files/rfid.js
@@ -182,10 +182,18 @@ const rfidVendor = {
     },
     circit: {
       name: 'circit',
-      port: "80/Temporary_Listen_Addresses",
+      // The Tech Logic CircIT reader listens on port 80 by default, serving
+      // its API under the "/Temporary_Listen_Addresses" path. The port can be
+      // overridden ( e.g. for testing, or non-standard installs ) via the
+      // koha_plugin_rfid.circit_port value the plugin injects into the page.
+      port: 80,
+      path: "/Temporary_Listen_Addresses",
       baseUrl: "",
       init: function () {
-        this.baseUrl = `http://localhost:${this.port}`;
+        const override =
+          window.koha_plugin_rfid && window.koha_plugin_rfid.circit_port;
+        const port = override || this.port;
+        this.baseUrl = `http://localhost:${port}${this.path}`;
       },
       checkAlive: async function () {
         try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,101 @@
         "node-datetime": "^2.0.0"
       },
       "devDependencies": {
+        "cypress": "^13.15.0",
         "gulp": "^4.0.2",
         "gulp-cli": "^3.0.0",
         "vinyl": "^3.0.0"
       }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cypress/request": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
+      "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~4.0.4",
+        "http-signature": "~1.4.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "performance-now": "^2.1.0",
+        "qs": "~6.14.1",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "^5.0.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@cypress/xvfb": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+      "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "lodash.once": "^4.1.1"
+      }
+    },
+    "node_modules/@cypress/xvfb/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@cypress/xvfb/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@gulpjs/messages": {
       "version": "1.1.0",
@@ -25,6 +116,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
+      "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-colors": {
@@ -38,6 +179,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-gray": {
@@ -60,6 +217,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ansi-wrap": {
@@ -108,6 +281,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/archy": {
       "version": "1.0.0",
@@ -274,6 +468,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -283,6 +497,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-done": {
       "version": "1.3.2",
@@ -333,6 +564,23 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -345,6 +593,23 @@
       "engines": {
         "node": ">= 4.5.0"
       }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/b4a": {
       "version": "1.6.7",
@@ -421,6 +686,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -441,6 +737,20 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/blob-util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+      "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -473,6 +783,41 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal": {
@@ -525,6 +870,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -575,6 +930,53 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -596,6 +998,22 @@
       },
       "optionalDependencies": {
         "fsevents": "^1.2.7"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/class-utils": {
@@ -639,6 +1057,62 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -817,6 +1291,46 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -927,6 +1441,134 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cypress": {
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
+      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cypress/request": "^3.0.6",
+        "@cypress/xvfb": "^1.2.4",
+        "@types/sinonjs__fake-timers": "8.1.1",
+        "@types/sizzle": "^2.3.2",
+        "arch": "^2.2.0",
+        "blob-util": "^2.0.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.7.1",
+        "cachedir": "^2.3.0",
+        "chalk": "^4.1.0",
+        "check-more-types": "^2.24.0",
+        "ci-info": "^4.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-table3": "~0.6.1",
+        "commander": "^6.2.1",
+        "common-tags": "^1.8.0",
+        "dayjs": "^1.10.4",
+        "debug": "^4.3.4",
+        "enquirer": "^2.3.6",
+        "eventemitter2": "6.4.7",
+        "execa": "4.1.0",
+        "executable": "^4.1.1",
+        "extract-zip": "2.0.1",
+        "figures": "^3.2.0",
+        "fs-extra": "^9.1.0",
+        "getos": "^3.2.1",
+        "is-installed-globally": "~0.4.0",
+        "lazy-ass": "^1.6.0",
+        "listr2": "^3.8.3",
+        "lodash": "^4.17.21",
+        "log-symbols": "^4.0.0",
+        "minimist": "^1.2.8",
+        "ospath": "^1.2.2",
+        "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
+        "proxy-from-env": "1.0.0",
+        "request-progress": "^3.0.0",
+        "semver": "^7.5.3",
+        "supports-color": "^8.1.1",
+        "tmp": "~0.2.3",
+        "tree-kill": "1.2.2",
+        "untildify": "^4.0.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "cypress": "bin/cypress"
+      },
+      "engines": {
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cypress/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cypress/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/d": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
@@ -940,6 +1582,26 @@
       "engines": {
         "node": ">=0.12"
       }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -1063,6 +1725,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -1155,6 +1827,17 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1170,6 +1853,53 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/enquirer/node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/enquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/error-ex": {
@@ -1209,6 +1939,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1280,6 +2026,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/esniff": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
@@ -1305,6 +2061,50 @@
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/executable": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+      "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/expand-brackets": {
@@ -1429,6 +2229,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/extract-zip/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
     "node_modules/fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
@@ -1458,6 +2314,32 @@
       "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -1676,6 +2558,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -1687,6 +2596,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fs-mkdirp-stream": {
@@ -1789,6 +2714,33 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream/node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -1797,6 +2749,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/getos": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
+      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.0"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob-parent": {
@@ -1939,6 +2911,32 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/global-dirs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-dirs/node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -1997,13 +2995,11 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "license": "ISC"
     },
     "node_modules/gulp": {
       "version": "4.0.2",
@@ -2051,39 +3047,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/gulp-cli/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/gulp-cli/node_modules/glogg": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-2.2.0.tgz",
@@ -2118,19 +3081,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/gulp/node_modules/camelcase": {
@@ -2522,6 +3472,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -2595,6 +3561,62 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
+    },
+    "node_modules/http-signature": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+      "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.18.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -2792,6 +3814,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-negated-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -2813,6 +3852,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-object": {
@@ -2838,6 +3887,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -2849,6 +3918,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-utf8": {
@@ -2894,12 +3976,69 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
     },
     "node_modules/just-debounce": {
       "version": "1.1.0",
@@ -2933,6 +4072,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "> 0.8"
       }
     },
     "node_modules/lazystream": {
@@ -3033,6 +4182,34 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/listr2": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
+      "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.1",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -3059,6 +4236,112 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/make-iterator": {
@@ -3162,6 +4445,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -3235,6 +4525,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mixin-deep": {
@@ -3422,6 +4755,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -3471,6 +4817,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-visit": {
@@ -3583,6 +4942,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ordered-read-streams": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
@@ -3644,6 +5019,29 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ospath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
+      "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse-filepath": {
@@ -3732,6 +5130,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -3775,6 +5183,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3829,6 +5251,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -3839,11 +5274,28 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "2.0.1",
@@ -3866,6 +5318,22 @@
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
         "pump": "^2.0.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/read-pkg": {
@@ -4093,6 +5561,16 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/request-progress": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+      "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "throttleit": "^1.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4166,6 +5644,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -4174,6 +5666,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -4191,6 +5700,13 @@
       "dependencies": {
         "ret": "~0.1.10"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "4.3.6",
@@ -4266,6 +5782,127 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/snapdragon": {
@@ -4472,6 +6109,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -4601,6 +6264,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -4666,6 +6355,23 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/throttleit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
+      "integrity": "sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -4724,6 +6430,36 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-absolute-glob": {
@@ -4836,12 +6572,75 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/type": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
       "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
@@ -4892,6 +6691,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -4917,6 +6724,16 @@
       "dependencies": {
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "through2-filter": "^3.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unset-value": {
@@ -4978,6 +6795,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -5013,6 +6840,17 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8flags": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-4.0.1.tgz",
@@ -5041,6 +6879,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/vinyl": {
@@ -5278,22 +7131,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -5359,6 +7196,17 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.1",
   "description": "Koha RFID Plugin",
   "devDependencies": {
+    "cypress": "^13.15.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^3.0.0",
     "vinyl": "^3.0.0"
@@ -12,7 +13,10 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "kpz": "node -e \"console.log(process.env.npm_package_name + '-v' + process.env.npm_package_version + '.kpz')\"",
     "print-name": "node -e \"console.log(process.env.npm_package_name)\"",
-    "build": "gulp build"
+    "build": "gulp build",
+    "cypress:open": "cypress open --project t/cypress",
+    "cypress:run": "cypress run --project t/cypress",
+    "cypress:suite": "bash t/cypress/run.sh"
   },
   "repository": {
     "type": "git",

--- a/t/cypress/README.md
+++ b/t/cypress/README.md
@@ -90,9 +90,13 @@ CYPRESS_emulatorUrl=http://127.0.0.1:4039 \
   (`-l http://127.0.0.1:PORT -l http://[::1]:PORT`). Note: don't use the
   wildcards `*` and `[::]` together — on Linux `[::]` is dual-stack and also
   grabs `0.0.0.0`, colliding with `*` so the emulator fails to start.
-- **circit** is omitted from the default `VENDORS`: it expects to listen on
-  privileged port 80 under the `/Temporary_Listen_Addresses` path, which
-  collides with the ktd Traefik proxy. Run it separately if needed.
+- **circit** runs on an unprivileged port during testing. The real reader uses
+  port 80 under the `/Temporary_Listen_Addresses` path (which also collides with
+  the ktd Traefik proxy), so `seed.pl` sets the `RFIDCircitPort` system
+  preference to point the plugin at `CIRCIT_TEST_PORT` (default 8090) and the
+  runner starts the emulator there. The plugin's CircIT port can be overridden
+  in production too, via the `KOHA_RFID_CIRCIT_PORT` environment variable or the
+  `RFIDCircitPort` system preference.
 - The issue #9 regression test seeds the plugin's `processed_barcodes`
   localStorage and asserts the batch checkout page never reloads — reproducing
   "the screen keeps jumping" and proving the fix.

--- a/t/cypress/README.md
+++ b/t/cypress/README.md
@@ -1,0 +1,95 @@
+# RFID plugin Cypress tests
+
+End-to-end tests for the RFID plugin. They drive a real Koha staff client in a
+browser and a real RFID reader emulator, exercising the plugin the same way a
+librarian's workstation does.
+
+## How it fits together
+
+```
+  Cypress (browser on host)
+        |  visits Koha staff client            -> ktd Koha (staff client)
+        |  plugin JS polls the RFID reader     -> RFID emulator (host, one vendor)
+        |  cy.request sets items "on the pad"   -> RFID emulator control API
+```
+
+- The plugin auto-detects the live RFID reader by probing each vendor in turn,
+  so **only one emulator may run at a time**. The suite is vendor-agnostic and
+  is run once per emulator; the same specs must pass for every vendor.
+- All three vendor emulators expose the same control API
+  (`POST /api/barcodes`, `GET /getitems`), so the `setPad` / `resetPad` helpers
+  work regardless of which vendor is running. The runner points them at the
+  live emulator via `CYPRESS_emulatorUrl`.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `cypress.config.js` | Config + env defaults (Koha URL, emulator URL, fixtures) |
+| `support/commands.js` | `loginToKoha`, `setPad`, `resetPad`, `visitBatchCheckout`, ... |
+| `support/e2e.js` | Per-test reset of plugin localStorage + the pad |
+| `integration/smoke.cy.js` | Plugin loads and detects the running reader |
+| `integration/batch_checkout.cy.js` | Happy path + issue #9 regression |
+| `seed.pl` | Creates the deterministic test patron + items (runs inside ktd) |
+| `fixtures/seed.json` | Written by the runner from `seed.pl`'s output |
+| `run.sh` | Runs the whole suite once per vendor emulator |
+
+## Prerequisites
+
+1. The **rfid-emulators** repo checked out (private:
+   `git@github.com:bywatersolutions/rfid-emulators.git`), with Perl +
+   Mojolicious available to run them.
+2. A **ktd** instance with the plugin mounted, installed, and **enabled**.
+3. Node + the plugin's dev dependencies (`npm install`, which installs Cypress).
+
+### One-time ktd setup
+
+```sh
+# From the plugin repo root. Use --proxy locally so it doesn't fight other ktd
+# instances for ports 8080/8081; the staff client is then at
+# http://<name>-intra.localhost
+SYNC_REPO=/path/to/koha \
+  ktd --proxy --name rfidtest --single-plugin "$(pwd)" up -d
+ktd --name rfidtest --wait-ready 300
+
+# Install AND enable the plugin, then restart so its API/static routes mount
+ktd --name rfidtest --shell --run "perl misc/devel/install_plugins.pl"
+ktd --name rfidtest --shell --run \
+  "echo \"INSERT INTO plugin_data (plugin_class,plugin_key,plugin_value) \
+    VALUES ('Koha::Plugin::Com::ByWaterSolutions::RFID','__ENABLED__','1') \
+    ON DUPLICATE KEY UPDATE plugin_value='1';\" | koha-mysql kohadev"
+ktd --name rfidtest --shell --run "sudo koha-plack --restart kohadev; flush_memcached"
+```
+
+## Running
+
+The runner starts each emulator, runs the suite, then stops it:
+
+```sh
+KTD_NAME=rfidtest \
+BASE_URL=http://rfidtest-intra.localhost \
+EMULATORS_DIR=/path/to/rfid-emulators \
+VENDORS="mksolutions bibliotheca" \
+  bash t/cypress/run.sh
+```
+
+Or via npm scripts (against a single, already-running emulator):
+
+```sh
+CYPRESS_baseUrl=http://rfidtest-intra.localhost \
+CYPRESS_emulatorUrl=http://127.0.0.1:4039 \
+  npm run cypress:open      # interactive
+```
+
+## Notes / gotchas
+
+- **One emulator at a time** (see above).
+- Emulators must listen on **both IPv4 and IPv6** — the bibliotheca/circit
+  vendors use the host `localhost`, which Chromium often resolves to `::1`
+  first. The runner launches them with `-l http://*:PORT -l http://[::]:PORT`.
+- **circit** is omitted from the default `VENDORS`: it expects to listen on
+  privileged port 80 under the `/Temporary_Listen_Addresses` path, which
+  collides with the ktd Traefik proxy. Run it separately if needed.
+- The issue #9 regression test seeds the plugin's `processed_barcodes`
+  localStorage and asserts the batch checkout page never reloads — reproducing
+  "the screen keeps jumping" and proving the fix.

--- a/t/cypress/README.md
+++ b/t/cypress/README.md
@@ -86,7 +86,10 @@ CYPRESS_emulatorUrl=http://127.0.0.1:4039 \
 - **One emulator at a time** (see above).
 - Emulators must listen on **both IPv4 and IPv6** — the bibliotheca/circit
   vendors use the host `localhost`, which Chromium often resolves to `::1`
-  first. The runner launches them with `-l http://*:PORT -l http://[::]:PORT`.
+  first. The runner launches them bound to both loopback addresses
+  (`-l http://127.0.0.1:PORT -l http://[::1]:PORT`). Note: don't use the
+  wildcards `*` and `[::]` together — on Linux `[::]` is dual-stack and also
+  grabs `0.0.0.0`, colliding with `*` so the emulator fails to start.
 - **circit** is omitted from the default `VENDORS`: it expects to listen on
   privileged port 80 under the `/Temporary_Listen_Addresses` path, which
   collides with the ktd Traefik proxy. Run it separately if needed.

--- a/t/cypress/cypress.config.js
+++ b/t/cypress/cypress.config.js
@@ -1,0 +1,41 @@
+const { defineConfig } = require("cypress");
+
+// All values can be overridden from the environment with the CYPRESS_ prefix,
+// e.g. CYPRESS_baseUrl=http://rfidtest-intra.localhost
+//      CYPRESS_emulatorUrl=http://127.0.0.1:21645
+module.exports = defineConfig({
+  // The plugin polls the RFID reader on a 500ms interval, so a single user
+  // action can take several seconds of polling before the UI settles. Give
+  // assertions a generous default so we wait for the poll loop rather than
+  // racing it.
+  defaultCommandTimeout: 15000,
+  video: false,
+  screenshotOnRunFailure: true,
+  e2e: {
+    baseUrl: "http://localhost:8081",
+    specPattern: "integration/**/*.cy.js",
+    supportFile: "support/e2e.js",
+    fixturesFolder: "fixtures",
+    screenshotsFolder: "screenshots",
+    // We talk to the RFID emulator from a different origin than Koha. The
+    // plugin's own XHR is allowed by the emulator's CORS headers, and our
+    // helper drives the emulator over cy.request ( which is not subject to
+    // same-origin ), so we don't need chromeWebSecurity disabled.
+    setupNodeEvents(on, config) {
+      return config;
+    },
+  },
+  env: {
+    // Koha staff login ( ktd default superlibrarian )
+    kohaUser: "koha",
+    kohaPass: "koha",
+
+    // The control API of whichever single emulator is currently running.
+    // The runner sets this per vendor; mksolutions is the default.
+    emulatorUrl: "http://127.0.0.1:4039",
+
+    // Deterministic fixtures created by t/cypress/seed.pl
+    patronCardnumber: "RFIDTESTPATRON",
+    itemBarcodes: ["RFIDTEST001", "RFIDTEST002", "RFIDTEST003"],
+  },
+});

--- a/t/cypress/integration/batch_checkout.cy.js
+++ b/t/cypress/integration/batch_checkout.cy.js
@@ -1,0 +1,79 @@
+// Behavioural specs for batch checkout, including the regression test for
+// issue #9 ( batch checkout cycling endlessly through already-processed items ).
+//
+// These are vendor-agnostic: they drive whatever emulator is running via the
+// pad helpers and assert on Koha's behaviour.
+
+describe("RFID batch checkout", () => {
+  const barcodes = Cypress.env("itemBarcodes");
+
+  beforeEach(() => {
+    cy.loginToKoha();
+  });
+
+  it("adds items on the pad to the batch checkout", () => {
+    cy.setPad(barcodes);
+    cy.visitBatchCheckout();
+
+    // The plugin picks the items off the pad, drops them in the barcode
+    // textarea, and submits the form. The resulting batch checkout view
+    // lists each item, so its barcode appears on the page.
+    barcodes.forEach(barcode => {
+      cy.contains(barcode, { timeout: 20000 }).should("exist");
+    });
+  });
+
+  it("does not keep cycling when the pad items are already processed (issue #9)", () => {
+    // Reproduce the reported condition: the items on the pad have already
+    // been processed and are "in the plugin's memory" ( its
+    // processed_barcodes list ). Seed that state before the page loads.
+    cy.setPad(barcodes);
+
+    // Count every page (re)load of the batch checkout page. Before the fix
+    // the plugin resubmitted the ( empty ) form on every poll, so the page
+    // reloaded over and over -- "the screen keeps jumping". After the fix
+    // it must stay on the entry form and never resubmit.
+    let loadCount = 0;
+    cy.on("window:before:load", () => {
+      loadCount += 1;
+    });
+
+    cy.visitBatchCheckout({
+      onBeforeLoad(win) {
+        win.localStorage.setItem(
+          "koha_plugin_rfid_processed_barcodes",
+          JSON.stringify(barcodes)
+        );
+        // Same action as last time, so the plugin keeps its memory
+        // instead of clearing it on an action change.
+        win.localStorage.setItem(
+          "koha_plugin_rfid_previous_action",
+          "batch_checkout"
+        );
+      },
+    });
+
+    // The entry form ( with #barcodelist ) should still be on screen --
+    // the plugin should not have submitted anything, because nothing on
+    // the pad is new.
+    cy.get("#barcodelist").should("exist");
+
+    // Let many poll cycles run ( the plugin polls every 500ms ). Capture
+    // the load count once things have had time to settle, then confirm it
+    // stops growing. With the bug, loadCount keeps climbing here.
+    cy.wait(3000);
+    cy.then(() => {
+      const settled = loadCount;
+      cy.wait(5000);
+      cy.then(() => {
+        expect(
+          loadCount,
+          "batch checkout should stop reloading once all pad items are already processed"
+        ).to.equal(settled);
+      });
+    });
+
+    // And we should still be on the entry form, not stuck reloading.
+    cy.get("#barcodelist").should("exist");
+  });
+});

--- a/t/cypress/integration/smoke.cy.js
+++ b/t/cypress/integration/smoke.cy.js
@@ -1,0 +1,26 @@
+// Smoke test: confirms the plugin loaded and detected whichever single RFID
+// emulator is currently running. This is the test that proves the harness is
+// wired up for the vendor under test before the behavioural specs run.
+
+describe("RFID plugin smoke test", () => {
+  beforeEach(() => {
+    cy.loginToKoha();
+  });
+
+  it("injects the plugin and detects the running RFID reader", () => {
+    cy.setPad(Cypress.env("itemBarcodes"));
+    cy.visitBatchCheckout();
+
+    // intranet_js injected rfid.js, which builds the floating "RFID
+    // Controls" box once a vendor has been detected.
+    cy.get("#rfid-reset-box", { timeout: 20000 }).should("be.visible");
+    cy.contains("#rfid-reset-box", "RFID Controls").should("be.visible");
+
+    // The plugin caches the detected vendor in localStorage. If detection
+    // succeeded this is set to the emulator that's currently running.
+    cy.window()
+      .its("localStorage")
+      .invoke("getItem", "koha_plugin_rfid_vendor")
+      .should("be.oneOf", ["mksolutions", "bibliotheca", "circit"]);
+  });
+});

--- a/t/cypress/run.sh
+++ b/t/cypress/run.sh
@@ -94,19 +94,30 @@ for vendor in $VENDORS; do
     echo ">> Vendor: $vendor  (emulator $script on $url)"
     echo "============================================================"
 
-    # Listen on both IPv4 and IPv6: the bibliotheca / circit vendors use the
-    # host "localhost", which Chromium often resolves to ::1 first, so an
-    # IPv4-only emulator would never be reached by the plugin.
+    # Listen on both loopback addresses: the bibliotheca / circit vendors use
+    # the host "localhost", which Chromium often resolves to ::1 first, so an
+    # IPv4-only emulator would never be reached by the plugin. Bind the
+    # specific loopback addresses ( 127.0.0.1 and [::1] ) rather than the
+    # wildcards "*" and "[::]" -- on Linux "[::]" is dual-stack and also grabs
+    # 0.0.0.0, which collides with "*" and makes the emulator fail to start.
     stop_emulator
     ( cd "$EMULATORS_DIR" && exec perl "$script" daemon \
-        -l "http://*:${port}" -l "http://[::]:${port}" ) &
+        -l "http://127.0.0.1:${port}" -l "http://[::1]:${port}" ) &
     EMULATOR_PID=$!
 
     # Wait for the emulator to answer
+    emulator_up=""
     for _ in $(seq 1 20); do
-        if curl -fs -o /dev/null "${url}/getitems"; then break; fi
+        if curl -fs -o /dev/null "${url}/getitems"; then emulator_up=1; break; fi
         sleep 0.5
     done
+
+    if [ -z "$emulator_up" ]; then
+        echo "!! Emulator for $vendor never came up on $url -- skipping" >&2
+        OVERALL_RC=1
+        stop_emulator
+        continue
+    fi
 
     if ! CYPRESS_baseUrl="$BASE_URL" CYPRESS_emulatorUrl="$url" \
         npx cypress run --project "$SCRIPT_DIR"; then

--- a/t/cypress/run.sh
+++ b/t/cypress/run.sh
@@ -33,7 +33,13 @@ KTD_NAME="${KTD_NAME:-rfidtest}"
 KTD_HOME="${KTD_HOME:-$HOME/repos/koha-testing-docker}"
 BASE_URL="${BASE_URL:-http://${KTD_NAME}-intra.localhost}"
 EMULATORS_DIR="${EMULATORS_DIR:-$HOME/repos/rfid-emulators}"
-VENDORS="${VENDORS:-mksolutions bibliotheca}"
+VENDORS="${VENDORS:-mksolutions bibliotheca circit}"
+
+# Port the circit emulator + plugin use during testing. The real reader uses
+# privileged port 80 ( which also collides with the ktd Traefik proxy ), so the
+# suite overrides it via the RFIDCircitPort system preference set in seed.pl;
+# this value MUST match the CIRCIT_PORT seed.pl writes.
+CIRCIT_TEST_PORT="${CIRCIT_TEST_PORT:-8090}"
 
 # Resolve the plugin repo root ( two levels up from this script )
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -41,9 +47,9 @@ PLUGIN_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PLUGIN_NAME="$(basename "$PLUGIN_DIR")"
 KTD="$KTD_HOME/bin/ktd"
 
-# Per-vendor emulator script + control URL. circit is intentionally omitted
-# from the default list: it expects to listen on privileged port 80 under the
-# /Temporary_Listen_Addresses path, which collides with the ktd Traefik proxy.
+# Per-vendor emulator script. circit normally uses privileged port 80; the
+# suite runs it on CIRCIT_TEST_PORT instead ( see seed.pl, which points the
+# plugin at that port via the RFIDCircitPort system preference ).
 emulator_script() {
     case "$1" in
         mksolutions) echo "mksolutions_emulator.pl" ;;
@@ -56,7 +62,7 @@ emulator_port() {
     case "$1" in
         mksolutions) echo "4039" ;;
         bibliotheca) echo "21645" ;;
-        circit)      echo "80" ;;
+        circit)      echo "$CIRCIT_TEST_PORT" ;;
         *) echo "unknown vendor: $1" >&2; return 1 ;;
     esac
 }

--- a/t/cypress/run.sh
+++ b/t/cypress/run.sh
@@ -37,8 +37,9 @@ VENDORS="${VENDORS:-mksolutions bibliotheca circit}"
 
 # Port the circit emulator + plugin use during testing. The real reader uses
 # privileged port 80 ( which also collides with the ktd Traefik proxy ), so the
-# suite overrides it via the RFIDCircitPort system preference set in seed.pl;
-# this value MUST match the CIRCIT_PORT seed.pl writes.
+# suite runs the emulator on this port and passes it to seed.pl, which points
+# the plugin at it via the RFIDCircitPort system preference. This is the single
+# source of truth for the circit test port.
 CIRCIT_TEST_PORT="${CIRCIT_TEST_PORT:-8090}"
 
 # Resolve the plugin repo root ( two levels up from this script )
@@ -81,7 +82,7 @@ trap stop_emulator EXIT
 echo ">> Seeding test data in ktd instance '$KTD_NAME'"
 mkdir -p "$SCRIPT_DIR/fixtures"
 SEED_JSON="$("$KTD" --name "$KTD_NAME" --shell --run \
-    "perl /kohadevbox/plugins/$PLUGIN_NAME/t/cypress/seed.pl" 2>/dev/null | tail -1)"
+    "perl /kohadevbox/plugins/$PLUGIN_NAME/t/cypress/seed.pl $CIRCIT_TEST_PORT" 2>/dev/null | tail -1)"
 if ! echo "$SEED_JSON" | grep -q borrowernumber; then
     echo "!! Seeding failed; got: $SEED_JSON" >&2
     exit 1

--- a/t/cypress/run.sh
+++ b/t/cypress/run.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# Run the RFID Cypress suite once per vendor emulator.
+#
+# The plugin auto-detects the live RFID reader by probing each vendor in turn,
+# so only ONE emulator may run at a time. This script starts each emulator,
+# runs the full suite against it, then moves on to the next -- the same specs
+# must pass for every vendor.
+#
+# Prerequisites:
+#   - A ktd instance running with the plugin mounted and installed, e.g.
+#       SYNC_REPO=/path/to/koha \
+#         ktd --proxy --name rfidtest \
+#             --single-plugin "$(pwd)" up -d
+#       ktd --name rfidtest --wait-ready 300
+#       ktd --name rfidtest --shell --run "perl misc/devel/install_plugins.pl"
+#   - The rfid-emulators repo checked out ( bibliotheca.pl, mksolutions_emulator.pl, ... )
+#   - Cypress installed ( npm install )
+#
+# Configurable via environment:
+#   KTD_NAME        ktd instance name           ( default: rfidtest )
+#   KTD_HOME        koha-testing-docker checkout ( default: ~/repos/koha-testing-docker )
+#   BASE_URL        Koha staff client URL        ( default: http://rfidtest-intra.localhost )
+#   EMULATORS_DIR   rfid-emulators checkout      ( default: ~/repos/rfid-emulators )
+#   VENDORS         space-separated vendor list  ( default: "mksolutions bibliotheca" )
+#
+# Usage:
+#   t/cypress/run.sh                 # run all default vendors
+#   VENDORS=bibliotheca t/cypress/run.sh
+set -euo pipefail
+
+KTD_NAME="${KTD_NAME:-rfidtest}"
+KTD_HOME="${KTD_HOME:-$HOME/repos/koha-testing-docker}"
+BASE_URL="${BASE_URL:-http://${KTD_NAME}-intra.localhost}"
+EMULATORS_DIR="${EMULATORS_DIR:-$HOME/repos/rfid-emulators}"
+VENDORS="${VENDORS:-mksolutions bibliotheca}"
+
+# Resolve the plugin repo root ( two levels up from this script )
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PLUGIN_NAME="$(basename "$PLUGIN_DIR")"
+KTD="$KTD_HOME/bin/ktd"
+
+# Per-vendor emulator script + control URL. circit is intentionally omitted
+# from the default list: it expects to listen on privileged port 80 under the
+# /Temporary_Listen_Addresses path, which collides with the ktd Traefik proxy.
+emulator_script() {
+    case "$1" in
+        mksolutions) echo "mksolutions_emulator.pl" ;;
+        bibliotheca) echo "bibliotheca.pl" ;;
+        circit)      echo "circit_emulator.pl" ;;
+        *) echo "unknown vendor: $1" >&2; return 1 ;;
+    esac
+}
+emulator_port() {
+    case "$1" in
+        mksolutions) echo "4039" ;;
+        bibliotheca) echo "21645" ;;
+        circit)      echo "80" ;;
+        *) echo "unknown vendor: $1" >&2; return 1 ;;
+    esac
+}
+
+EMULATOR_PID=""
+stop_emulator() {
+    if [ -n "$EMULATOR_PID" ]; then
+        kill "$EMULATOR_PID" 2>/dev/null || true
+        wait "$EMULATOR_PID" 2>/dev/null || true
+        EMULATOR_PID=""
+    fi
+}
+trap stop_emulator EXIT
+
+# Seed deterministic test data ( patron + items ) and capture the fixture.
+echo ">> Seeding test data in ktd instance '$KTD_NAME'"
+mkdir -p "$SCRIPT_DIR/fixtures"
+SEED_JSON="$("$KTD" --name "$KTD_NAME" --shell --run \
+    "perl /kohadevbox/plugins/$PLUGIN_NAME/t/cypress/seed.pl" 2>/dev/null | tail -1)"
+if ! echo "$SEED_JSON" | grep -q borrowernumber; then
+    echo "!! Seeding failed; got: $SEED_JSON" >&2
+    exit 1
+fi
+echo "$SEED_JSON" > "$SCRIPT_DIR/fixtures/seed.json"
+echo "   seed.json: $SEED_JSON"
+
+OVERALL_RC=0
+for vendor in $VENDORS; do
+    script="$(emulator_script "$vendor")"
+    port="$(emulator_port "$vendor")"
+    url="http://127.0.0.1:${port}"
+
+    echo
+    echo "============================================================"
+    echo ">> Vendor: $vendor  (emulator $script on $url)"
+    echo "============================================================"
+
+    # Listen on both IPv4 and IPv6: the bibliotheca / circit vendors use the
+    # host "localhost", which Chromium often resolves to ::1 first, so an
+    # IPv4-only emulator would never be reached by the plugin.
+    stop_emulator
+    ( cd "$EMULATORS_DIR" && exec perl "$script" daemon \
+        -l "http://*:${port}" -l "http://[::]:${port}" ) &
+    EMULATOR_PID=$!
+
+    # Wait for the emulator to answer
+    for _ in $(seq 1 20); do
+        if curl -fs -o /dev/null "${url}/getitems"; then break; fi
+        sleep 0.5
+    done
+
+    if ! CYPRESS_baseUrl="$BASE_URL" CYPRESS_emulatorUrl="$url" \
+        npx cypress run --project "$SCRIPT_DIR"; then
+        echo "!! Suite FAILED for vendor $vendor" >&2
+        OVERALL_RC=1
+    fi
+
+    stop_emulator
+done
+
+exit "$OVERALL_RC"

--- a/t/cypress/seed.pl
+++ b/t/cypress/seed.pl
@@ -42,9 +42,10 @@ C4::Context->set_preference( "BatchCheckoutsValidCategories", $categorycode );
 warn "Enabled BatchCheckouts for category '$categorycode' at library '$branchcode'\n";
 
 # The real CircIT reader uses privileged port 80; point the plugin at the
-# unprivileged port the circit emulator runs on during testing. This MUST match
-# CIRCIT_TEST_PORT in t/cypress/run.sh.
-my $circit_test_port = 8090;
+# unprivileged port the circit emulator runs on during testing. The runner
+# passes that port ( CIRCIT_TEST_PORT ) as the first argument so there's a
+# single source of truth; fall back to 8090 if run on its own.
+my $circit_test_port = ( $ARGV[0] && $ARGV[0] =~ /\A[0-9]+\z/ ) ? $ARGV[0] : 8090;
 C4::Context->set_preference( "RFIDCircitPort", $circit_test_port );
 warn "Set RFIDCircitPort to $circit_test_port\n";
 

--- a/t/cypress/seed.pl
+++ b/t/cypress/seed.pl
@@ -41,6 +41,13 @@ C4::Context->set_preference( "BatchCheckouts",               1 );
 C4::Context->set_preference( "BatchCheckoutsValidCategories", $categorycode );
 warn "Enabled BatchCheckouts for category '$categorycode' at library '$branchcode'\n";
 
+# The real CircIT reader uses privileged port 80; point the plugin at the
+# unprivileged port the circit emulator runs on during testing. This MUST match
+# CIRCIT_TEST_PORT in t/cypress/run.sh.
+my $circit_test_port = 8090;
+C4::Context->set_preference( "RFIDCircitPort", $circit_test_port );
+warn "Set RFIDCircitPort to $circit_test_port\n";
+
 # Find or create the test patron
 my $patron = Koha::Patrons->find( { cardnumber => $cardnumber } );
 unless ($patron) {

--- a/t/cypress/seed.pl
+++ b/t/cypress/seed.pl
@@ -1,0 +1,114 @@
+#!/usr/bin/env perl
+
+# Seed deterministic data for the RFID Cypress suite.
+#
+# Run INSIDE the ktd koha container ( it needs Koha's Perl environment ):
+#   ktd --name rfidtest --shell --run "perl /kohadevbox/plugins/koha-plugin-rfid/t/cypress/seed.pl"
+#
+# It is idempotent: re-running reuses the existing patron / items and just
+# makes sure they're loanable and not currently checked out, so the suite can
+# run over and over. The only thing printed to STDOUT is a single JSON line
+# that the runner captures into t/cypress/fixtures/seed.json; everything else
+# goes to STDERR.
+
+use Modern::Perl;
+
+use Mojo::JSON qw(encode_json);
+use MARC::Record;
+
+use C4::Context;
+use C4::Biblio      qw(AddBiblio);
+use C4::Circulation qw(AddReturn);
+
+use Koha::Patrons;
+use Koha::Patron::Categories;
+use Koha::Libraries;
+use Koha::Items;
+use Koha::ItemTypes;
+
+my $cardnumber = "RFIDTESTPATRON";
+my @barcodes   = qw( RFIDTEST001 RFIDTEST002 RFIDTEST003 );
+
+# Pick a real library and item type from the sample data
+my $branchcode = Koha::Libraries->search( {}, { rows => 1 } )->next->branchcode;
+my $itemtype   = Koha::ItemTypes->search( {}, { rows => 1 } )->next->itemtype;
+
+# Use a real patron category and make batch checkout valid for it
+my $categorycode =
+    Koha::Patron::Categories->search( {}, { rows => 1 } )->next->categorycode;
+
+C4::Context->set_preference( "BatchCheckouts",               1 );
+C4::Context->set_preference( "BatchCheckoutsValidCategories", $categorycode );
+warn "Enabled BatchCheckouts for category '$categorycode' at library '$branchcode'\n";
+
+# Find or create the test patron
+my $patron = Koha::Patrons->find( { cardnumber => $cardnumber } );
+unless ($patron) {
+    $patron = Koha::Patron->new(
+        {
+            cardnumber   => $cardnumber,
+            surname      => "RFID",
+            firstname    => "Test",
+            categorycode => $categorycode,
+            branchcode   => $branchcode,
+            userid       => "rfidtestpatron",
+        }
+    )->store;
+    warn "Created patron $cardnumber\n";
+}
+
+# Find or create the test items, reusing a single biblio
+my $biblionumber;
+my @existing = grep { $_ } map { Koha::Items->find( { barcode => $_ } ) } @barcodes;
+$biblionumber = $existing[0]->biblionumber if @existing;
+
+unless ($biblionumber) {
+    my $record = MARC::Record->new();
+    $record->append_fields(
+        MARC::Field->new( "245", "", "", "a" => "RFID Cypress Test Record" ) );
+    ($biblionumber) = AddBiblio( $record, "" );
+    warn "Created biblio $biblionumber\n";
+}
+
+for my $barcode (@barcodes) {
+    my $item = Koha::Items->find( { barcode => $barcode } );
+    if ($item) {
+        # Make sure it's loanable and located at our test library
+        $item->set(
+            {
+                homebranch    => $branchcode,
+                holdingbranch => $branchcode,
+                notforloan    => 0,
+                itemlost      => 0,
+                withdrawn     => 0,
+                damaged       => 0,
+            }
+        )->store;
+    } else {
+        $item = Koha::Item->new(
+            {
+                biblionumber  => $biblionumber,
+                barcode       => $barcode,
+                homebranch    => $branchcode,
+                holdingbranch => $branchcode,
+                itype         => $itemtype,
+                notforloan    => 0,
+            }
+        )->store;
+        warn "Created item $barcode\n";
+    }
+
+    # If it's checked out ( from a previous run ), return it so the suite repeats
+    if ( $item->checkout ) {
+        AddReturn( $barcode, $branchcode );
+        warn "Returned previously checked-out item $barcode\n";
+    }
+}
+
+print encode_json(
+    {
+        borrowernumber => $patron->borrowernumber + 0,
+        cardnumber     => $cardnumber,
+        barcodes       => \@barcodes,
+    }
+) . "\n";

--- a/t/cypress/support/commands.js
+++ b/t/cypress/support/commands.js
@@ -1,0 +1,63 @@
+// Custom commands for driving Koha + the RFID emulator from Cypress.
+//
+// The emulator control API is identical across all three vendor emulators
+// ( mksolutions, bibliotheca, circit ), so these helpers don't care which one
+// is running -- they just talk to whatever emulator is listening on
+// Cypress.env("emulatorUrl"). Only one emulator runs at a time because the
+// plugin auto-detects the live vendor by probing each in turn.
+
+const RFID_LOCALSTORAGE_KEYS = [
+  "koha_plugin_rfid_enabled",
+  "koha_plugin_rfid_vendor",
+  "koha_plugin_rfid_previous_action",
+  "koha_plugin_rfid_unprocessed_barcodes",
+  "koha_plugin_rfid_processed_barcodes",
+  "koha_plugin_rfid_show_reset_box",
+  "koha_plugin_rfid_show_barcode_box",
+];
+
+// Wipe the plugin's localStorage so each test starts from a known state.
+Cypress.Commands.add("clearRfidLocalStorage", () => {
+  cy.window({ log: false }).then(win => {
+    RFID_LOCALSTORAGE_KEYS.forEach(key => win.localStorage.removeItem(key));
+  });
+});
+
+// Set the items "on the pad". Accepts a string or an array of barcodes.
+Cypress.Commands.add("setPad", barcodes => {
+  const list = Array.isArray(barcodes) ? barcodes.join(" ") : barcodes;
+  cy.request({
+    method: "POST",
+    url: `${Cypress.env("emulatorUrl")}/api/barcodes`,
+    body: { barcodes: list },
+  });
+});
+
+// Clear the pad ( no items present ).
+Cypress.Commands.add("resetPad", () => {
+  cy.setPad("");
+});
+
+// Log in to the staff client once and reuse the session across tests.
+Cypress.Commands.add("loginToKoha", () => {
+  cy.session("koha-staff", () => {
+    cy.visit("/cgi-bin/koha/mainpage.pl");
+    cy.get("#userid").type(Cypress.env("kohaUser"));
+    cy.get("#password").type(`${Cypress.env("kohaPass")}{enter}`);
+    // On a successful login the username field is gone from the page.
+    cy.get("#userid").should("not.exist");
+  });
+});
+
+// Visit the batch checkout page for the seeded test patron. Reads the
+// borrowernumber written by seed.pl into the seed.json fixture. Any options
+// ( e.g. onBeforeLoad ) are passed straight through to cy.visit.
+Cypress.Commands.add("visitBatchCheckout", (options = {}) => {
+  cy.fixture("seed.json").then(seed => {
+    cy.visit(
+      `/cgi-bin/koha/circ/circulation.pl?borrowernumber=${seed.borrowernumber}&batch=1`,
+      options
+    );
+    cy.contains("h1", "Batch check out").should("be.visible");
+  });
+});

--- a/t/cypress/support/e2e.js
+++ b/t/cypress/support/e2e.js
@@ -1,0 +1,13 @@
+import "./commands";
+
+// The plugin stores quite a bit of state in localStorage ( the detected
+// vendor, the previous action, and the unprocessed / processed barcode
+// lists ). Leftover state from a previous test would change how the plugin
+// behaves on the next page load, so start every test from a clean slate.
+beforeEach(() => {
+  cy.clearRfidLocalStorage();
+  cy.resetPad();
+});
+
+// Don't let an exception thrown by unrelated Koha page JS fail an RFID test.
+Cypress.on("uncaught:exception", () => false);


### PR DESCRIPTION
Brings the test/tooling work from the issue-9 branch onto current `main`. The batch-checkout cycling fix itself already landed on `main` separately, so that commit was dropped during the rebase; what remains is the test harness plus the CircIT port-override work.

## What's here

**Cypress end-to-end tests** (`t/cypress/`)
- Driver-emulator-based E2E suite so the plugin's circulation flows can be exercised in CI against a real Koha (KTD) instance.
- `integration/smoke.cy.js`, `integration/batch_checkout.cy.js`
- Support, fixtures, `seed.pl`, `run.sh`, and a `README.md` documenting how to run it locally.
- `.github/workflows/cypress.yml` to run the suite in CI.
- Coverage for the CircIT vendor, with the emulator port wired as a single source of truth.

**CircIT reader port override**
- Adds the ability to configure the port CircIT listens on (`RFID.pm` + `rfid.js`), rather than assuming a fixed port.

**CI housekeeping**
- Bumps GitHub Actions off the deprecated Node 20 runtime.
- Fixes emulator startup in CI by binding loopback addresses.

## Notes
- Rebased cleanly onto current `main` (`7c11989`); no conflicts with the recent checkout hold-confirmation fix.
- `package-lock.json` grows because the Cypress dev dependency is added.

## Test plan
1) Check out the branch
2) Run the Cypress suite per `t/cypress/README.md` (or let the new `cypress.yml` workflow run it in CI)
3) Note the smoke and batch-checkout specs pass against a KTD instance with the plugin installed